### PR TITLE
Revert growth to default true

### DIFF
--- a/src/com/untamedears/realisticbiomes/listener/GrowListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/GrowListener.java
@@ -166,8 +166,8 @@ public class GrowListener implements Listener {
 			return Math.random() < config.getRate(b);
 		}
 		
-		// Default to no growth
-		return false;
+		// Default to growth if not cofigured
+		return true;
 	}
 	
 


### PR DESCRIPTION
This was originally true to allow non-configured types to use vanilla behavior, compare to willGrow(TreeType, Block). Specifically it started blocking bonemeal on grass in 1.7.10, as discussed here: http://www.reddit.com/r/Civcraft/comments/2h5112/civcraft_changelog_for_20140922/ckpw1ue
