### PR TITLE
enable glowstone on saplings

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -212,6 +212,8 @@ realistic_biomes:
    needs_sunlight: true
    not_full_sunlight_multiplier: 0.125
    max_soil_layers: 0
+   greenhouse_rate: 0.75
+   greenhouse_ignore_biome: true
    biomes:
     mushroom: 0.5
     freshwater: 0.5


### PR DESCRIPTION
Glowstone will give all saplings 75% of base growth (0.75% jungle, 3% others)

Notably allows oak trees to be grown in the End
