### PR TITLE
Fix: Reloading of config only done if default created.

### DIFF
--- a/src/com/untamedears/realisticbiomes/RealisticBiomes.java
+++ b/src/com/untamedears/realisticbiomes/RealisticBiomes.java
@@ -75,8 +75,11 @@ public class RealisticBiomes extends JavaPlugin implements Listener {
 		if (!this.getConfig().isSet("realistic_biomes")) {
 			this.saveDefaultConfig();
 			this.getLogger().warning("Config did not exist or was invalid, default config saved.");
+			
+			// Reload the config into memory from the newly created default file.
+			this.reloadConfig();
 		}
-		this.reloadConfig();
+		
 		
 		ConfigurationSection config = this.getConfig().getConfigurationSection("realistic_biomes");
 


### PR DESCRIPTION
**Problem**: The configuration file was being "reloaded" from file regardless of the creation or non-creation of a default configuration. (Loaded twice when the file was fine.)

**Fix**: The reloading is done only if a default configuration had to be created into the data directory due to a missing or corrupted configuration (command was moved inside the conditional block).