### PR TITLE
Cocoa persistence

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -195,7 +195,7 @@ realistic_biomes:
    needs_sunlight: true
    base_rate: 0.1
    not_full_sunlight_multiplier: 0.2
-   #persistent_growth_period: 24
+   persistent_growth_period: 24
    # get incremental bonus from an unbroken chain of up to 25 
    # vines starting directly below the cocoa pod
    soil_material: VINE

--- a/src/com/untamedears/realisticbiomes/RealisticBiomes.java
+++ b/src/com/untamedears/realisticbiomes/RealisticBiomes.java
@@ -383,8 +383,10 @@ public class RealisticBiomes extends JavaPlugin {
 	// grow the specified block, return the new growth magnitude
 	// gets called when the user hits a block manually!!
 	public double growAndPersistBlock(Block block, boolean naturalGrowEvent) {
-		GrowthConfig growthConfig = getGrowthConfig(block);
-		
+		return growAndPersistBlock(block, naturalGrowEvent, getGrowthConfig(block));
+	}
+	
+	public double growAndPersistBlock(Block block, boolean naturalGrowEvent, GrowthConfig growthConfig) {
 		RealisticBiomes.doLog(Level.FINER, "RealisticBiomes:growAndPersistBlock() called for block: " + block + " and is naturalGrowEvent? " + naturalGrowEvent);
 		if (!persistConfig.enabled)
 			return 0.0;

--- a/src/com/untamedears/realisticbiomes/listener/GrowListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/GrowListener.java
@@ -54,7 +54,7 @@ public class GrowListener implements Listener {
 		
 		GrowthConfig growthConfig = plugin.getGrowthConfig(b);
 		if (plugin.persistConfig.enabled && growthConfig != null && growthConfig.isPersistent()) {
-			plugin.growAndPersistBlock(b, true);
+			plugin.growAndPersistBlock(b, true, growthConfig);
 			
 			event.setCancelled(true);
 		}

--- a/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
@@ -130,7 +130,7 @@ public class PlayerListener implements Listener {
 				GrowthConfig growthConfig = growthConfigs.get(material);
 				if (plugin.persistConfig.enabled && growthConfig != null && growthConfig.isPersistent()) {
 					
-					plantGrowth = plugin.growAndPersistBlock(block, false);
+					plantGrowth = plugin.growAndPersistBlock(block, false, growthConfig);
 				}
 			}
 			else {


### PR DESCRIPTION
Before moving on to other crops, I did some cleanup of cocoa persistence. I remember there was a bug with cocoa persistence, and in the config it is commented-out so I assume it was disabled for buggy behaviour.

Previously the age of cocoa was set with deprecated `Block.setData` and quite some magic to set the correct bits, I changed this to using bukkit's MaterialData API.

I have tested locally and it seemed like it works correctly, cocoa pods were set to their correct age when loading chunks.
