### PR TITLE
Fruits

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -152,7 +152,7 @@ realistic_biomes:
 
   MELON_BLOCK:
    inherit: crop
-   persistent_growth_period: 12
+   persistent_growth_period: 3
    soil_max_layers: 0
    base_rate: 0.32
    biomes:
@@ -162,7 +162,7 @@ realistic_biomes:
 
   PUMPKIN:
    inherit: crop
-   persistent_growth_period: 12
+   persistent_growth_period: 3
    soil_max_layers: 0
    base_rate: 0.32
    biomes:

--- a/config.yml
+++ b/config.yml
@@ -152,6 +152,7 @@ realistic_biomes:
 
   MELON_BLOCK:
    inherit: crop
+   persistent_growth_period: 12
    soil_max_layers: 0
    base_rate: 0.32
    biomes:
@@ -161,6 +162,7 @@ realistic_biomes:
 
   PUMPKIN:
    inherit: crop
+   persistent_growth_period: 12
    soil_max_layers: 0
    base_rate: 0.32
    biomes:

--- a/src/com/untamedears/realisticbiomes/RealisticBiomes.java
+++ b/src/com/untamedears/realisticbiomes/RealisticBiomes.java
@@ -427,7 +427,7 @@ public class RealisticBiomes extends JavaPlugin {
 			RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growAndPersistBlock(): creating new plant and adding it");
 			
 			plant = new Plant((float)BlockGrower.getGrowthFraction(block),
-					(float)BlockGrower.getFruitGrowthFraction(block));
+					(float)BlockGrower.getFruitGrowthFraction(block, fruitBlockToIgnore));
 			plantManager.addPlant(block, plant);
 		}
 		
@@ -435,6 +435,7 @@ public class RealisticBiomes extends JavaPlugin {
 		
 		if (plant.isFullyGrown()) {
 			// if plant is fully grown and either has no fruits or fruit has fully grown, stop tracking it
+			RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growAndPersistBlock(): removing fully grown plant: " + plant);
 			plantManager.removePlant(block);
 		}
 		

--- a/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.TreeType;
 import org.bukkit.block.Block;
@@ -16,6 +17,8 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.material.Dye;
+import org.bukkit.material.MaterialData;
 
 import com.untamedears.realisticbiomes.GrowthConfig;
 import com.untamedears.realisticbiomes.RealisticBiomes;
@@ -91,124 +94,135 @@ public class PlayerListener implements Listener {
 		Plant plant = null;
 		
 		// right click block with the seeds or plant in hand to see what the status is
-		if (event.getAction() == Action.LEFT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
-			Object material = event.getMaterial()/*in hand*/;
-			Block block = event.getClickedBlock();
+		if (event.getAction() != Action.LEFT_CLICK_BLOCK && event.getAction() != Action.RIGHT_CLICK_BLOCK) {
+			return;
+		}
 			
-			if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
-				// hit the ground with a seed, or other farm product: get the adjusted crop growth
-				// rate as if that crop was planted on top of the block
-				material = materialAliases.get(material);
-				// if the material isn't aliased, just use the material
-				if (material == null)
-					material = event.getMaterial();
-				
-				// handle saplings as their tree types
-				if (event.getItem() != null && event.getItem().getTypeId() == Material.SAPLING.getId()) {
-					int data = event.getItem().getData().getData();
-					if (saplingIndexMap.containsKey(data)) {
-						material = saplingIndexMap.get(data);
-					}
+		Object material = event.getMaterial()/*in hand*/;
+		Block block = event.getClickedBlock();
+		
+		if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
+			// hit the ground with a seed, or other farm product: get the adjusted crop growth
+			// rate as if that crop was planted on top of the block
+			material = materialAliases.get(material);
+			// if the material isn't aliased, just use the material
+			if (material == null)
+				material = event.getMaterial();
+			
+			// handle saplings as their tree types
+			if (event.getItem() != null && event.getItem().getTypeId() == Material.SAPLING.getId()) {
+				int data = event.getItem().getData().getData();
+				if (saplingIndexMap.containsKey(data)) {
+					material = saplingIndexMap.get(data);
 				}
-				
-				
-				// don't do anything if the material is a dye, but not cocoa
-				if (event.getMaterial() == Material.INK_SACK && event.getItem().getData().getData() != 3/*cocoa*/)
+			}
+			
+//			RealisticBiomes.doLog(Level.FINER, "CLICKY: " + event.getItem().getData());
+			
+			// don't do anything if the material is a dye, but not cocoa brown
+			if (event.getMaterial() == Material.INK_SACK) {
+				MaterialData data = event.getItem().getData();
+				if ((data instanceof Dye) && ((Dye)data).getColor() != DyeColor.BROWN) {
 					return;
+				}
+			}
+			
+		}
+		else if (event.getAction() == Action.RIGHT_CLICK_BLOCK && (material == Material.STICK || material == Material.BONE)) {
+			// right click on a growing crop with a stick: get information about that crop
+			material = event.getClickedBlock().getType();
+			
+			// handle saplings as their tree types
+			int index = block.getData();
+			if (material == Material.SAPLING && saplingIndexMap.containsKey(index)) {
 				
+				material = saplingIndexMap.get(index);
+			}
+			
+			GrowthConfig growthConfig = growthConfigs.get(material);
+			if (plugin.persistConfig.enabled && growthConfig != null && growthConfig.isPersistent()) {
+				
+				plant = plugin.growAndPersistBlock(block, false, growthConfig, null);
+			}
+		}
+		else {
+			// right clicked without stick or bone, do nothing
+			return;
+		}
+		
+		// show growth rate information if the item in the player's hand is not a bone
+		if (event.getMaterial() == Material.BONE) {
+			return;
+		}
+		
+		block = event.getClickedBlock();
+		if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
+			// from hitting something with material in hand
+			if (material == Material.COCOA) {
+				block = block.getRelative(event.getBlockFace());
+			} else {
 				block = block.getRelative(0,1,0);
 			}
-			else if (event.getAction() == Action.RIGHT_CLICK_BLOCK && (material == Material.STICK || material == Material.BONE)) {
-				// right click on a growing crop with a stick: get information about that crop
-				material = event.getClickedBlock().getType();
-				
-				// handle saplings as their tree types
-				int index = block.getData();
-				if (material == Material.SAPLING && saplingIndexMap.containsKey(index)) {
-					
-					material = saplingIndexMap.get(index);
-				}
-				
-				GrowthConfig growthConfig = growthConfigs.get(material);
-				if (plugin.persistConfig.enabled && growthConfig != null && growthConfig.isPersistent()) {
-					
-					plant = plugin.growAndPersistBlock(block, false, growthConfig, null);
-				}
-			}
-			else {
-				// right clicked without stick, do nothing
-				return;
-			}
+		}
+		
+		GrowthConfig growthConfig = growthConfigs.get(material);
+		if (growthConfig == null)
+			return;
+
+		if (plugin.persistConfig.enabled && growthConfig.isPersistent()) {
+			double rate = growthConfig.getRate(block);
+			RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): rate for " + material + " at block " + block + " is " + rate);
+			rate = (1.0/(rate*(60.0*60.0/*seconds per hour*/)));
+			RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): rate adjusted to "  + rate);
 			
-			// show growth rate information if the item in the player's hand is not a bone
-			if (event.getMaterial() != Material.BONE) {
-				block = event.getClickedBlock();
-				if (event.getAction() == Action.LEFT_CLICK_BLOCK) 
-					block = block.getRelative(0,1,0);
-				else if (material == Material.PUMPKIN || material == Material.MELON_BLOCK || material == Material.CACTUS) {
-					block = block.getRelative(0,1,0);
-				}
+			if (plant == null) {
+				String amount = new DecimalFormat("#0.00").format(rate);
+				event.getPlayer().sendMessage("§7[Realistic Biomes] \""+material.toString()+"\": "+amount+" hours to maturity");
 				
-				GrowthConfig growthConfig = growthConfigs.get(material);
-				if (growthConfig == null)
-					return;
-
-				if (plugin.persistConfig.enabled && growthConfig.isPersistent()) {
-					double rate = growthConfig.getRate(block);
-					RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): rate for block " + block + " is " + rate);
-					rate = (1.0/(rate*(60.0*60.0/*seconds per hour*/)));
-					RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): rate adjusted to "  + rate);
+			} else if (plant.getGrowth() == 1.0) {
+				if (Fruits.isFruitFul(block.getType())) {
 					
-					if (plant == null) {
-						String amount = new DecimalFormat("#0.00").format(rate);
-						event.getPlayer().sendMessage("§7[Realistic Biomes] \""+material.toString()+"\": "+amount+" hours to maturity");
-						
-					} else if (plant.getGrowth() == 1.0) {
-						if (Fruits.isFruitFul(block.getType())) {
+					if (!Fruits.hasFruit(block)) {
+						Material fruitMaterial = Fruits.getFruit(event.getClickedBlock().getType());
+						growthConfig = growthConfigs.get(fruitMaterial);
+						block = Fruits.getFreeBlock(event.getClickedBlock(), null);
+						if (block != null) {
+							double fruitRate = growthConfig.getRate(block);
+							RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate for block " + block + " is " + fruitRate);
+							fruitRate = (1.0/(fruitRate*(60.0*60.0/*seconds per hour*/)));
+							RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate adjusted to "  + fruitRate);
 							
-							if (!Fruits.hasFruit(block)) {
-								Material fruitMaterial = Fruits.getFruit(event.getClickedBlock().getType());
-								growthConfig = growthConfigs.get(fruitMaterial);
-								block = Fruits.getFreeBlock(event.getClickedBlock(), null);
-								if (block != null) {
-									double fruitRate = growthConfig.getRate(block);
-									RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate for block " + block + " is " + fruitRate);
-									fruitRate = (1.0/(fruitRate*(60.0*60.0/*seconds per hour*/)));
-									RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate adjusted to "  + fruitRate);
-									
-									String amount = new DecimalFormat("#0.00").format(fruitRate);
-									String pAmount = new DecimalFormat("#0.00").format(fruitRate*(1.0-plant.getFruitGrowth()));
-									event.getPlayer().sendMessage("§7[Realistic Biomes] \""+fruitMaterial.toString()+"\": "+pAmount+" of "+amount+" hours to maturity");
-									return;
-								}
-							}
-							
+							String amount = new DecimalFormat("#0.00").format(fruitRate);
+							String pAmount = new DecimalFormat("#0.00").format(fruitRate*(1.0-plant.getFruitGrowth()));
+							event.getPlayer().sendMessage("§7[Realistic Biomes] \""+fruitMaterial.toString()+"\": "+pAmount+" of "+amount+" hours to maturity");
+							return;
 						}
-						
-						
-						String amount = new DecimalFormat("#0.00").format(rate);
-						event.getPlayer().sendMessage("§7[Realistic Biomes] \""+material.toString()+"\": "+amount+" hours to maturity");
-
-					} else {
-						String amount = new DecimalFormat("#0.00").format(rate);
-						String pAmount = new DecimalFormat("#0.00").format(rate*(1.0-plant.getGrowth()));
-						event.getPlayer().sendMessage("§7[Realistic Biomes] \""+material.toString()+"\": "+pAmount+" of "+amount+" hours to maturity");
 					}
 					
-				} else {
-					// Persistence is not enabled
-					double growthAmount = growthConfig.getRate(block);
-					
-					// clamp the growth value between 0 and 1 and put into percent format
-					if (growthAmount > 1.0)
-						growthAmount = 1.0;
-					else if (growthAmount < 0.0)
-						growthAmount = 0.0;
-					String amount = new DecimalFormat("#0.00").format(growthAmount*100.0)+"%";
-					// send the message out to the user!
-					event.getPlayer().sendMessage("§7[Realistic Biomes] Growth rate \""+material.toString()+"\" = "+amount);
 				}
+				
+				
+				String amount = new DecimalFormat("#0.00").format(rate);
+				event.getPlayer().sendMessage("§7[Realistic Biomes] \""+material.toString()+"\": "+amount+" hours to maturity");
+
+			} else {
+				String amount = new DecimalFormat("#0.00").format(rate);
+				String pAmount = new DecimalFormat("#0.00").format(rate*(1.0-plant.getGrowth()));
+				event.getPlayer().sendMessage("§7[Realistic Biomes] \""+material.toString()+"\": "+pAmount+" of "+amount+" hours to maturity");
 			}
+			
+		} else {
+			// Persistence is not enabled
+			double growthAmount = growthConfig.getRate(block);
+			
+			// clamp the growth value between 0 and 1 and put into percent format
+			if (growthAmount > 1.0)
+				growthAmount = 1.0;
+			else if (growthAmount < 0.0)
+				growthAmount = 0.0;
+			String amount = new DecimalFormat("#0.00").format(growthAmount*100.0)+"%";
+			// send the message out to the user!
+			event.getPlayer().sendMessage("§7[Realistic Biomes] Growth rate \""+material.toString()+"\" = "+amount);
 		}
 	}
 	

--- a/src/com/untamedears/realisticbiomes/persist/BlockGrower.java
+++ b/src/com/untamedears/realisticbiomes/persist/BlockGrower.java
@@ -3,12 +3,16 @@ package com.untamedears.realisticbiomes.persist;
 import java.util.HashMap;
 import java.util.logging.Logger;
 
+import org.bukkit.CropState;
 import org.bukkit.Material;
+import org.bukkit.NetherWartsState;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.material.CocoaPlant;
 import org.bukkit.material.CocoaPlant.CocoaPlantSize;
+import org.bukkit.material.Crops;
 import org.bukkit.material.MaterialData;
+import org.bukkit.material.NetherWarts;
 
 // handles force-growing of crop-type blocks based on a fractional growth amount
 public class BlockGrower {
@@ -38,9 +42,15 @@ public class BlockGrower {
 		this.plantManager = plantManager;
 	}
 	
-	// grow the crop found at the given block/coordinates, with the amount or growth
-	// between 0 and 1, with 1 being totally mature
-	public void growBlock(Block block, float growth) {
+	/**
+	 * grow the crop or stem found at the given block's coordinates with the amount
+	 * between 0 and 1, with 1 being totally mature
+	 * @param block Block to grow
+	 * @param growth Block's growth, between 0 and 1
+	 * @param fruitGrowth Fruit growth, -1 if fruitless of 0 - 1 if stem
+	 */
+	@SuppressWarnings("deprecation")
+	public void growBlock(Block block, float growth, float fruitGrowth) {
 		Integer stages = growthStages.get(block.getType());
 		if (stages == null)
 			return;
@@ -56,13 +66,41 @@ public class BlockGrower {
 			// trust that enum order is sanely declared in order SMALL, MEDIUM, LARGE
 			CocoaPlantSize cocoaSize = CocoaPlantSize.values()[stage]; 
 			((CocoaPlant)data).setSize(cocoaSize);
+		} else if (data instanceof Crops) {
+			// trust that enum order is sanely declared in order
+			CropState cropSize = CropState.values()[stage]; 
+			((Crops)data).setState(cropSize);
+		} else if (data instanceof NetherWarts) {
+			// trust that enum order is sanely declared in order
+			NetherWartsState cropSize = NetherWartsState.values()[stage]; 
+			((NetherWarts)data).setState(cropSize);
 		} else {
 			data.setData(stage);
 		}
 		state.setData(data);
 		state.update(true, false);
+		
+		if (fruitGrowth != -1.0) {
+			this.growFruit(block, fruitGrowth);
+		}
 	}
 	
+	private void growFruit(Block block, float fruitGrowth) {
+		if (Fruits.hasFruit(block)) {
+			return;
+		}
+		
+		if (fruitGrowth < 1.0) {
+			return;
+		}
+		
+		Block freeBlock = Fruits.getFreeBlock(block, null);
+		if (freeBlock != null) {
+			freeBlock.setType(Fruits.getFruit(block.getType()));
+		}
+	}
+	
+	@SuppressWarnings("deprecation")
 	public static double getGrowthFraction(Block block) {
 		if (!growthStages.containsKey(block.getType()))
 			return 0.0;
@@ -83,9 +121,14 @@ public class BlockGrower {
 					stage = 2;
 					break;
 			}
+			
 		} else {
 			stage = data.getData();
 		}
 		return (double)stage/(double)(growthStages.get(block.getType())-1);
+	}
+
+	public static float getFruitGrowthFraction(Block block) {
+		return Fruits.hasFruit(block) ? 1.0f : 0.0f;
 	}
 }

--- a/src/com/untamedears/realisticbiomes/persist/BlockGrower.java
+++ b/src/com/untamedears/realisticbiomes/persist/BlockGrower.java
@@ -128,7 +128,7 @@ public class BlockGrower {
 		return (double)stage/(double)(growthStages.get(block.getType())-1);
 	}
 
-	public static float getFruitGrowthFraction(Block block) {
-		return Fruits.hasFruit(block) ? 1.0f : 0.0f;
+	public static float getFruitGrowthFraction(Block block, Block fruitBlockToIgnore) {
+		return Fruits.hasFruit(block, fruitBlockToIgnore) ? 1.0f : 0.0f;
 	}
 }

--- a/src/com/untamedears/realisticbiomes/persist/ChunkWriter.java
+++ b/src/com/untamedears/realisticbiomes/persist/ChunkWriter.java
@@ -39,13 +39,13 @@ public class ChunkWriter {
 			addChunkStmt = writeConn.prepareStatement(String.format("INSERT INTO %s_chunk (w, x, z) VALUES (?, ?, ?)", config.prefix));
 			getLastChunkIdStmt = writeConn.prepareStatement("SELECT LAST_INSERT_ID()");	
 			
-			addPlantStmt = writeConn.prepareStatement(String.format("INSERT INTO %s_plant (chunkid, w, x, y, z, date, growth) VALUES (?, ?, ?, ?, ?, ?, ?)", config.prefix));
+			addPlantStmt = writeConn.prepareStatement(String.format("INSERT INTO %s_plant (chunkid, w, x, y, z, date, growth, fruitGrowth) VALUES (?, ?, ?, ?, ?, ?, ?, ?)", config.prefix));
 			// don't need for now,...maybe later?
 			//updatePlantStmt = writeConn.prepareStatement(String.format("UPDATE %s_plant SET date = ?, growth = ? where chunkid = ?", config.prefix));
 			deleteOldPlantsStmt = writeConn.prepareStatement(String.format("DELETE FROM %s_plant WHERE chunkid = ?", config.prefix));
 
 			loadPlantsStmt = readConn.prepareStatement(String
-								.format("SELECT w, x, y, z, date, growth FROM %s_plant WHERE chunkid = ?",
+								.format("SELECT w, x, y, z, date, growth, fruitGrowth FROM %s_plant WHERE chunkid = ?",
 										config.prefix));
 
 

--- a/src/com/untamedears/realisticbiomes/persist/Fruits.java
+++ b/src/com/untamedears/realisticbiomes/persist/Fruits.java
@@ -1,0 +1,117 @@
+package com.untamedears.realisticbiomes.persist;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.util.Vector;
+
+/**
+ * Fruit related helper functions. This could be optimized: convert this
+ * into non-static, and create and instance per check that caches surrounding
+ * block materials etc.
+ */
+public class Fruits {
+
+	static List<Vector> surroundingBlocks = new ArrayList<Vector>();
+	static {
+		surroundingBlocks.add(new Vector(-1,0,0));	// west
+		surroundingBlocks.add(new Vector(1,0,0));	// east
+		surroundingBlocks.add(new Vector(0,0,-1));	// north
+		surroundingBlocks.add(new Vector(0,0,1));	// south
+	}
+	
+	public static boolean isFruitFul(Material material) {
+		return material == Material.MELON_STEM || material == Material.PUMPKIN_STEM;
+	}
+	
+	public static boolean isFruit(Material material) {
+		return material == Material.MELON_BLOCK || material == Material.PUMPKIN;
+	}
+
+	public static boolean hasFruit(Block block) {
+		return hasFruit(block, null);
+	}
+
+	/**
+	 * Check if stem at block has ANY fruit next to it.
+	 * @param block
+	 * @param blockToIgnore Ignore this block for this check
+	 * @return true if the stem has a fruit
+	 */
+	public static boolean hasFruit(Block block, Block blockToIgnore) {
+		Material fruit = getFruit(block.getType());
+		for(Vector vec : surroundingBlocks) {
+			Block candidate = block.getLocation().add(vec).getBlock();
+			if (blockToIgnore != null && candidate.getLocation().equals(blockToIgnore.getLocation())) {
+				continue;
+			}
+			if (candidate.getType() == fruit) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Find an air block over dirt, grass or farmland adjacent to given block.
+	 * @param block Center to search from
+	 * @param blockToIgnore Ignore these possibly adjacent blocks
+	 * @return free block or null if none
+	 */
+	public static Block getFreeBlock(Block block, Block blockToIgnore) {
+		Block air = null;
+		for( Vector vec : surroundingBlocks ) {
+			Block candidate = block.getLocation().add(vec).getBlock();
+			if (candidate.getType() == Material.AIR
+					|| (blockToIgnore != null && candidate.getLocation().equals(blockToIgnore.getLocation()))) {
+				Material soil = candidate.getRelative(BlockFace.DOWN).getType();
+				if (soil == Material.DIRT || soil == Material.SOIL || soil == Material.GRASS) {
+					air = candidate;
+				}
+			}
+		}
+		return air;
+	}
+
+	public static Material getFruit(Material material) {
+		if (material == Material.PUMPKIN_STEM) {
+			return Material.PUMPKIN;
+		} else if (material == Material.MELON_STEM) {
+			return Material.MELON_BLOCK;
+		} else {
+			return null;
+		}
+	}
+	
+	public static Material getStem(Material material) {
+		if (material == Material.PUMPKIN) {
+			return Material.PUMPKIN_STEM;
+		} else if (material == Material.MELON_BLOCK) {
+			return Material.MELON_STEM;
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Get a list of stems adjacent to given block
+	 * @param block
+	 * @return List of stems, can have from zero to four entries
+	 */
+	public static List<Block> getStems(Block block) {
+		Material stem = getStem(block.getType());
+		ArrayList<Block> candidates = new ArrayList<Block>();
+		for( Vector vec : surroundingBlocks ) {
+			Block candidate = block.getLocation().add(vec).getBlock();
+			if (candidate.getType() == stem && BlockGrower.getGrowthFraction(candidate) >= 1.0) {
+				if (!Fruits.hasFruit(candidate, block)) {
+					candidates.add(candidate);
+				}
+			}
+		}
+		return candidates;
+	}
+
+}

--- a/src/com/untamedears/realisticbiomes/persist/Fruits.java
+++ b/src/com/untamedears/realisticbiomes/persist/Fruits.java
@@ -2,6 +2,8 @@ package com.untamedears.realisticbiomes.persist;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -96,12 +98,12 @@ public class Fruits {
 	}
 
 	/**
-	 * Get a list of stems adjacent to given block
+	 * Get a list of stems adjacent to given block that do not have any other fruits adjacent to them
 	 * @param block
 	 * @return List of stems, can have from zero to four entries
 	 */
-	public static List<Block> getStems(Block block) {
-		Material stem = getStem(block.getType());
+	public static List<Block> getStems(Block block, Material fruitMaterial) {
+		Material stem = getStem(fruitMaterial);
 		ArrayList<Block> candidates = new ArrayList<Block>();
 		for( Vector vec : surroundingBlocks ) {
 			Block candidate = block.getLocation().add(vec).getBlock();

--- a/src/com/untamedears/realisticbiomes/persist/Fruits.java
+++ b/src/com/untamedears/realisticbiomes/persist/Fruits.java
@@ -3,7 +3,6 @@ package com.untamedears.realisticbiomes.persist;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;

--- a/src/com/untamedears/realisticbiomes/persist/Plant.java
+++ b/src/com/untamedears/realisticbiomes/persist/Plant.java
@@ -1,49 +1,86 @@
 package com.untamedears.realisticbiomes.persist;
 
-// represents the growth status of a single plant
-
+/**
+ * Represents the abstract growth status of a single plant, without references to blocks
+ * or any other minecraft stuff
+ */
 public class Plant {
 	// time of the last update, in milliseconds
 	long lastUpdateTime;
 	// the growth amount of this plant
 	// ranges from 0.0 to 1.0
 	float growth;
+	// the fruit growth amount from this plant (melons, cacti...)
+	float fruitGrowth;
 	
-	public Plant(long lastUpdateTime) {
-		this.lastUpdateTime = lastUpdateTime;
-		growth = 0.0f;
+	public Plant(float growth, float fruitGrowth) {
+		// divide by 1000 to get unix/epoch time, we don't need millisecond precision
+		// also fixes bug where the timestamp would be too big for the mysql rb_plant date column
+		this(System.currentTimeMillis() / 1000L, growth, fruitGrowth);
 	}
 	
-	public Plant(long lastUpdateTime, float growth) {
+	public Plant(long lastUpdateTime, float growth, float fruitGrowth) {
 		this.lastUpdateTime = lastUpdateTime;
 		this.growth = growth;
+		if (growth < 1.0) {
+			fruitGrowth = -1.0f;
+		}
+		this.fruitGrowth = fruitGrowth;
 	}
 	
 	// update the time, return the time since the last update in ms
-	public float setUpdateTime(long time) {
-		float diff = (float)(time-lastUpdateTime);
+	private float updateTime() {
+		long time = System.currentTimeMillis() / 1000L;
+		float diff = time - lastUpdateTime;
 		
 		lastUpdateTime = time;
 		return diff;
 	}
 	
-	long getUpdateTime() {
+	public long getUpdateTime() {
 		return lastUpdateTime;
 	}
 	
-	public void addGrowth(float amount) {
-		growth += amount;
-		if (growth > 1.0)
-			growth = 1.0f;
+	/**
+	 * Sets last-update-time to now, sets growth for time diff since last update, and returns time diff.
+	 * The time diff return value must be used for growFruit()
+	 * @param rate
+	 * @return time since last update/grow in seconds
+	 */
+	public double grow(double rate) {
+		float diff = updateTime();
+		double amount = rate * diff;
+		
+		growth = (float) Math.min(growth + amount, 1.0);
+		
+		return diff;
 	}
 	
+	public void growFruit(double diff, double fruitRate) {
+		double fruitAmount = fruitRate * diff;
+		fruitGrowth = (float) Math.min(fruitGrowth + fruitAmount, 1.0);
+	}
+
 	public float getGrowth() {
 		return growth;
 	}
 	
+	public float getFruitGrowth() {
+		return fruitGrowth;
+	}
+	
 	public String toString() {
-	
-		return "<Plant lastUpdateTime: " + lastUpdateTime + " growth: " + growth + ">";
-	
+		return "<Plant lastUpdateTime: " + lastUpdateTime + " growth: " + growth + " fruit: " + fruitGrowth + ">";
+	}
+
+	/**
+	 * @return true if fully grown, and either fruitless or fruit is also fully grown
+	 */
+	public boolean isFullyGrown() {
+		return growth >= 1.0f && (fruitGrowth == -1.0f || fruitGrowth >= 1.0f);
+	}
+
+	public void setFruitGrowth(float fruitState) {
+		this.fruitGrowth = fruitState;
 	}
 }

--- a/src/com/untamedears/realisticbiomes/persist/PlantChunk.java
+++ b/src/com/untamedears/realisticbiomes/persist/PlantChunk.java
@@ -157,6 +157,7 @@ public class PlantChunk {
 				int z = rs.getInt("z");
 				long date = rs.getLong(5);
 				float growth = rs.getFloat(6);
+				float fruitGrowth = rs.getFloat(7);
 
 				RealisticBiomes.doLog(Level.FINEST, String
 								.format("PlantChunk.load(): got result: w:%s x:%s y:%s z:%s date:%s growth:%s",
@@ -169,7 +170,7 @@ public class PlantChunk {
 					continue;
 				}
 
-				Plant plant = new Plant(date, growth);
+				Plant plant = new Plant(date, growth, fruitGrowth);
 
 				// TODO MARK: this code seems very similar to
 				// RealisticBiomes.growAndPersistBlock()
@@ -177,16 +178,12 @@ public class PlantChunk {
 				Block block = world.getBlockAt(x, y, z);
 				GrowthConfig growthConfig = plugin.getGrowthConfig(block);
 				if (growthConfig.isPersistent()) {
-					double growthAmount = growthConfig.getRate(block)
-							* plant.setUpdateTime(System.currentTimeMillis() / 1000L);
-					plant.addGrowth((float) growthAmount);
-
-					// and update the plant growth
-					plugin.getBlockGrower().growBlock(block, plant.getGrowth());
+					plugin.growPlant(plant, block, growthConfig, null);
 				}
+
 				// if the plant isn't finished growing, add it to the
 				// plants
-				if (!(plant.getGrowth() >= 1.0)) {
+				if (!plant.isFullyGrown()) {
 					plants.put(new Coords(w, x, y, z), plant);
 					RealisticBiomes.doLog(Level.FINER, "PlantChunk.load(): plant not finished growing, adding to plants list");
 				}
@@ -307,6 +304,8 @@ public class PlantChunk {
 								plant.getUpdateTime());
 						ChunkWriter.addPlantStmt.setFloat(7,
 								plant.getGrowth());
+						ChunkWriter.addPlantStmt.setFloat(8,
+								plant.getFruitGrowth());
 						
 						ChunkWriter.addPlantStmt.addBatch();
 						


### PR DESCRIPTION
pumkins and melons' fruit growth is stored as extra field.

Keeping track of fruit growth is more expensive than crops:

* must track block break to start tracking a fruit's growth again after harvest (unlike crops which simply get replanted)
* must search for nearby stems on break
* a stem must search for both free spot and possibly existing fruit each time it's growth time is checked
* also tracks piston events for BUD auto farms (although internally a bit poor - plant may spawn, get removed from DB, then right after get broken by piston, then added again. a future contraption could improve this with better yield as incentive or something, if necessary.)

There is room for future improvements at Fruits.java as noted in comment.

 ---

Cactus and sugarcane will probably use the same principle, but won't need that much block checks, jsut the block above.  
Trees don't need to track "fruits" since a sapling only grows once. But I want to move away both from magic-numbers/data-ids for tree types and make the internal [material/treetype/other?] to growthconfig map typesafer.