### PR TITLE
Fruits fixes

### DIFF
--- a/src/com/untamedears/realisticbiomes/GrowthConfig.java
+++ b/src/com/untamedears/realisticbiomes/GrowthConfig.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 import org.bukkit.Material;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.util.Vector;
 
@@ -211,7 +212,12 @@ public class GrowthConfig extends BaseConfig {
 		}
 		
 		// modulate the rate by the amount of sunlight recieved by this plant
-		int sunlightIntensity = block.getLightFromSky();
+		int sunlightIntensity;
+		if (block.getType().isTransparent()) {
+			sunlightIntensity = block.getLightFromSky();
+		} else {
+			sunlightIntensity = block.getRelative(BlockFace.UP).getLightFromSky();
+		}
 		if (needsSunlight) {
 			environmentMultiplier *= Math.pow((sunlightIntensity / MAX_LIGHT_INTENSITY), 3.0);
 		}

--- a/src/com/untamedears/realisticbiomes/RealisticBiomes.java
+++ b/src/com/untamedears/realisticbiomes/RealisticBiomes.java
@@ -444,10 +444,12 @@ public class RealisticBiomes extends JavaPlugin {
 	
 	/**
 	 * Grow the plant
+	 * If not `fruitBlockToIgnore` is not null, this comes from BlockBreak. The event needs this, since
+	 * the block being broken is still in world until event has completed.
 	 * @param plant
 	 * @param block
 	 * @param growthConfig
-	 * @param fruitBlockToIgnore When checking for fruits, ignore this block. BlockBreak event needs this, since the block being broken is still in world until event has completed.
+	 * @param fruitBlockToIgnore When checking for fruits, ignore this block
 	 */
 	public void growPlant(Plant plant, Block block, GrowthConfig growthConfig, Block fruitBlockToIgnore) {
 		double rate = growthConfig.getRate(block);
@@ -456,25 +458,30 @@ public class RealisticBiomes extends JavaPlugin {
 		RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): plant existed, growthAmount was: " + plant.getGrowth());
 		double updateTime = plant.grow(rate);
 		
-		if (Fruits.isFruitFul(block.getType()) && plant.getGrowth() >= 1.0 && !Fruits.hasFruit(block, fruitBlockToIgnore)) {
+		if (Fruits.isFruitFul(block.getType())) {
+			boolean hasFruit = Fruits.hasFruit(block, fruitBlockToIgnore);
 			GrowthConfig fruitGrowthConfig = getGrowthConfig(Fruits.getFruit(block.getType()));
-			if (fruitGrowthConfig.isPersistent()) {
-			
-				if (plant.getFruitGrowth() == -1.0) {
-					// first time a stem is fully grown, reset fruit to zero
+			if (fruitGrowthConfig.isPersistent()) {	
+				if (!hasFruit && plant.getGrowth() >= 1.0) {	
+					if (plant.getFruitGrowth() == -1.0) {
+						// first time a stem is fully grown, reset fruit to zero
+						plant.setFruitGrowth(0.0f);
+					}
+					
+					Block freeBlock = Fruits.getFreeBlock(block, fruitBlockToIgnore);
+					if (freeBlock != null) {
+						// got a free spot, now grow a fruit there with the fruit's conditions
+						fruitRate = fruitGrowthConfig.getRate(freeBlock);
+						
+						RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): fruit rate: " + fruitRate);
+						
+						plant.growFruit(updateTime, fruitRate);
+					} else {
+						RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): no free block for fruit");
+					}
+
+				} else if (hasFruit) {
 					plant.setFruitGrowth(0.0f);
-				}
-				
-				Block freeBlock = Fruits.getFreeBlock(block, fruitBlockToIgnore);
-				if (freeBlock != null) {
-					// got a free spot, now grow a fruit there with the fruit's conditions
-					fruitRate = fruitGrowthConfig.getRate(freeBlock);
-					
-					RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): fruit rate: " + fruitRate);
-					
-					plant.growFruit(updateTime, fruitRate);
-				} else {
-					RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): no free block for fruit");
 				}
 			}
 		}

--- a/src/com/untamedears/realisticbiomes/RealisticBiomes.java
+++ b/src/com/untamedears/realisticbiomes/RealisticBiomes.java
@@ -457,22 +457,25 @@ public class RealisticBiomes extends JavaPlugin {
 		double updateTime = plant.grow(rate);
 		
 		if (Fruits.isFruitFul(block.getType()) && plant.getGrowth() >= 1.0 && !Fruits.hasFruit(block, fruitBlockToIgnore)) {
-			if (plant.getFruitGrowth() == -1.0) {
-				// first time a stem is fully grown, reset fruit to zero
-				plant.setFruitGrowth(0.0f);
-			}
+			GrowthConfig fruitGrowthConfig = getGrowthConfig(Fruits.getFruit(block.getType()));
+			if (fruitGrowthConfig.isPersistent()) {
 			
-			Block freeBlock = Fruits.getFreeBlock(block, fruitBlockToIgnore);
-			if (freeBlock != null) {
-				// got a free spot, now grow a fruit there with the fruit's conditions
-				GrowthConfig fruitGrowthConfig = getGrowthConfig(Fruits.getFruit(block.getType()));
-				fruitRate = fruitGrowthConfig.getRate(freeBlock);
+				if (plant.getFruitGrowth() == -1.0) {
+					// first time a stem is fully grown, reset fruit to zero
+					plant.setFruitGrowth(0.0f);
+				}
 				
-				RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): fruit rate: " + fruitRate);
-				
-				plant.growFruit(updateTime, fruitRate);
-			} else {
-				RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): no free block for fruit");
+				Block freeBlock = Fruits.getFreeBlock(block, fruitBlockToIgnore);
+				if (freeBlock != null) {
+					// got a free spot, now grow a fruit there with the fruit's conditions
+					fruitRate = fruitGrowthConfig.getRate(freeBlock);
+					
+					RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): fruit rate: " + fruitRate);
+					
+					plant.growFruit(updateTime, fruitRate);
+				} else {
+					RealisticBiomes.doLog(Level.FINER, "Realisticbiomes.growPlant(): no free block for fruit");
+				}
 			}
 		}
 		

--- a/src/com/untamedears/realisticbiomes/listener/GrowListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/GrowListener.java
@@ -56,7 +56,7 @@ public class GrowListener implements Listener {
 		Material material = event.getNewState().getType();
 		Block block = event.getBlock();
 		
-		if (growFruit(block, material)) {
+		if (growFruit(block, material, false)) {
 			event.setCancelled(true);
 			return;
 		}
@@ -227,6 +227,7 @@ public class GrowListener implements Listener {
 		// unless it is a fruit, then it's persistence is handled by the stem
 		Block block = event.getBlockPlaced();
 		if (Fruits.isFruit(block.getType())) {
+			growFruit(block, false);
 			return;
 		}
 		GrowthConfig growthConfig = plugin.getGrowthConfig(block);
@@ -240,8 +241,7 @@ public class GrowListener implements Listener {
 	public void onBlockBreak(BlockBreakEvent event) {
 		if (!plugin.persistConfig.enabled)
 			return;
-		
-		growFruit(event.getBlock());
+		growFruit(event.getBlock(), true);
 	}
 	
 	@EventHandler
@@ -249,7 +249,7 @@ public class GrowListener implements Listener {
 		if (!plugin.persistConfig.enabled)
 			return;
 		for (Block block: event.getBlocks()) {
-			growFruit(block);
+			growFruit(block, true);
 		}
 	}
 	
@@ -257,17 +257,17 @@ public class GrowListener implements Listener {
 	public void on(BlockPistonRetractEvent event) {
 		if (!plugin.persistConfig.enabled)
 			return;
-		growFruit(event.getBlock());
+		growFruit(event.getBlock(), true);
 	}
 	
 	/**
 	 * Get all touching stems and attempt to restart their fruit growth
 	 */
-	private boolean growFruit(Block block) {
-		return growFruit(block, block.getType());
+	private boolean growFruit(Block block, boolean ignore) {
+		return growFruit(block, block.getType(), ignore);
 	}
 	
-	private boolean growFruit(Block block, Material material) {
+	private boolean growFruit(Block block, Material material, boolean ignore) {
 		if (!Fruits.isFruit(material)) {
 			return false;
 		}
@@ -278,7 +278,7 @@ public class GrowListener implements Listener {
 		}
 		
 		// only ignore block if it comes from a break event 
-		Block ignoreBlock = block.getType() == Material.AIR ? null : block;
+		Block ignoreBlock = ignore ? block : null;
 		
 		for (Block stem: Fruits.getStems(block, material)) {
 			plugin.growAndPersistBlock(stem, true, growthConfig, ignoreBlock);

--- a/src/com/untamedears/realisticbiomes/listener/GrowListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/GrowListener.java
@@ -272,11 +272,16 @@ public class GrowListener implements Listener {
 			return false;
 		}
 		
+		GrowthConfig growthConfig = plugin.getGrowthConfig(material);
+		if (!growthConfig.isPersistent()) {
+			return false;
+		}
+		
 		// only ignore block if it comes from a break event 
 		Block ignoreBlock = block.getType() == Material.AIR ? null : block;
 		
 		for (Block stem: Fruits.getStems(block, material)) {
-			plugin.growAndPersistBlock(stem, true, null, ignoreBlock);
+			plugin.growAndPersistBlock(stem, true, growthConfig, ignoreBlock);
 		}
 		return true;
 	}

--- a/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
@@ -127,8 +127,7 @@ public class PlayerListener implements Listener {
 				}
 			}
 			
-		}
-		else if (event.getAction() == Action.RIGHT_CLICK_BLOCK && (material == Material.STICK || material == Material.BONE)) {
+		} else if (event.getAction() == Action.RIGHT_CLICK_BLOCK && (material == Material.STICK || material == Material.BONE)) {
 			// right click on a growing crop with a stick: get information about that crop
 			material = event.getClickedBlock().getType();
 			
@@ -144,8 +143,8 @@ public class PlayerListener implements Listener {
 				
 				plant = plugin.growAndPersistBlock(block, false, growthConfig, null);
 			}
-		}
-		else {
+			
+		} else {
 			// right clicked without stick or bone, do nothing
 			return;
 		}
@@ -166,8 +165,9 @@ public class PlayerListener implements Listener {
 		}
 		
 		GrowthConfig growthConfig = growthConfigs.get(material);
-		if (growthConfig == null)
+		if (growthConfig == null) {
 			return;
+		}
 
 		if (plugin.persistConfig.enabled && growthConfig.isPersistent()) {
 			double rate = growthConfig.getRate(block);
@@ -185,17 +185,19 @@ public class PlayerListener implements Listener {
 					if (!Fruits.hasFruit(block)) {
 						Material fruitMaterial = Fruits.getFruit(event.getClickedBlock().getType());
 						growthConfig = growthConfigs.get(fruitMaterial);
-						block = Fruits.getFreeBlock(event.getClickedBlock(), null);
-						if (block != null) {
-							double fruitRate = growthConfig.getRate(block);
-							RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate for block " + block + " is " + fruitRate);
-							fruitRate = (1.0/(fruitRate*(60.0*60.0/*seconds per hour*/)));
-							RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate adjusted to "  + fruitRate);
-							
-							String amount = new DecimalFormat("#0.00").format(fruitRate);
-							String pAmount = new DecimalFormat("#0.00").format(fruitRate*(1.0-plant.getFruitGrowth()));
-							event.getPlayer().sendMessage("§7[Realistic Biomes] \""+fruitMaterial.toString()+"\": "+pAmount+" of "+amount+" hours to maturity");
-							return;
+						if (growthConfig.isPersistent()) {
+							block = Fruits.getFreeBlock(event.getClickedBlock(), null);
+							if (block != null) {
+								double fruitRate = growthConfig.getRate(block);
+								RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate for block " + block + " is " + fruitRate);
+								fruitRate = (1.0/(fruitRate*(60.0*60.0/*seconds per hour*/)));
+								RealisticBiomes.doLog(Level.FINER, "PlayerListener.onPlayerInteractEvent(): fruit rate adjusted to "  + fruitRate);
+								
+								String amount = new DecimalFormat("#0.00").format(fruitRate);
+								String pAmount = new DecimalFormat("#0.00").format(fruitRate*(1.0-plant.getFruitGrowth()));
+								event.getPlayer().sendMessage("§7[Realistic Biomes] \""+fruitMaterial.toString()+"\": "+pAmount+" of "+amount+" hours to maturity");
+								return;
+							}
 						}
 					}
 					

--- a/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
+++ b/src/com/untamedears/realisticbiomes/listener/PlayerListener.java
@@ -138,10 +138,12 @@ public class PlayerListener implements Listener {
 				material = saplingIndexMap.get(index);
 			}
 			
-			GrowthConfig growthConfig = growthConfigs.get(material);
-			if (plugin.persistConfig.enabled && growthConfig != null && growthConfig.isPersistent()) {
-				
-				plant = plugin.growAndPersistBlock(block, false, growthConfig, null);
+			if (!Fruits.isFruit((Material) material)) {
+				GrowthConfig growthConfig = growthConfigs.get(material);
+				if (plugin.persistConfig.enabled && growthConfig != null && growthConfig.isPersistent()) {
+					
+					plant = plugin.growAndPersistBlock(block, false, growthConfig, null);
+				}
 			}
 			
 		} else {
@@ -154,7 +156,6 @@ public class PlayerListener implements Listener {
 			return;
 		}
 		
-		block = event.getClickedBlock();
 		if (event.getAction() == Action.LEFT_CLICK_BLOCK) {
 			// from hitting something with material in hand
 			if (material == Material.COCOA) {


### PR DESCRIPTION
* check if fruits are actually configured to be persistent before doing persistence
* when hitting a fruit with stick, do not attempt to grow it (was futile anyway, just wastes cpu)
* pumpkins and melons are the only non-transparent crops, for these take the light level from one block above when getting growth rate, as otherwise it is reported as zero. This will only happen when right clicking the block with a stick.
* minor code readibilty improvement in GrowListener
* always set the fruit growth of a stem to zero if a fruit is found nearby
