### PR TITLE
Glowstone multiplier change

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -227,7 +227,7 @@ realistic_biomes:
    needs_sunlight: true
    not_full_sunlight_multiplier: 0.125
    greenhouse_rate: 0.75
-   greenhouse_ignore_biome: true
+   greenhouse_ignore_biome: false
    biomes:
     mushroom: 0.5
     freshwater: 0.5

--- a/config.yml
+++ b/config.yml
@@ -54,7 +54,7 @@ realistic_biomes:
    # greenhouse is represented by immediate proximity of a glowstone block with light level 14
    greenhouse_rate: 0.75
    # if this flag is true, then the greenhouse growth will also ignore biome growth rates
-   greenhouse_ignore_biome: true
+   greenhouse_ignore_biome: false
    # if this flag is true, the growth rate of the grower is modulated by sunlight levels
    # ie sunlight level = 15 means full growth, while sunlight level 0 means 0 growth
    # sunlight level is disregarded is this flag is false


### PR DESCRIPTION
Changing the way glowstone works, so it multiplies the biome growth rate instead of the base growth rate to prevent players from stacking farms in a 0% growthrate biome thanks to glowstone.

https://forum.civcraft.co/t/making-glowstone-multiply-the-growth-rate-of-the-biome-instead-of-the-base-rate/697