### PR TITLE
getRate() rewrite (squashed for Max)

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -53,8 +53,6 @@ realistic_biomes:
    # the rate at which plants will grow in an artificial environment, sunlight factor will be ignored
    # greenhouse is represented by immediate proximity of a glowstone block with light level 14
    greenhouse_rate: 0.75
-   # if this flag is true, then the greenhouse growth will also ignore biome growth rates
-   greenhouse_ignore_biome: true
    # if this flag is true, the growth rate of the grower is modulated by sunlight levels
    # ie sunlight level = 15 means full growth, while sunlight level 0 means 0 growth
    # sunlight level is disregarded is this flag is false
@@ -227,7 +225,6 @@ realistic_biomes:
    needs_sunlight: true
    not_full_sunlight_multiplier: 0.125
    greenhouse_rate: 0.75
-   greenhouse_ignore_biome: true
    biomes:
     mushroom: 0.5
     freshwater: 0.5


### PR DESCRIPTION
Five squashed commits. Rebased against current master and merged.

# The first commit's message is:
getRate() rewrite

# This is the 2nd commit message:

Cleanup of unused stuff

Cleaned up and removed unused stuff for water irrigation and
greenhouse_ignore_biome. Also changed getRate, so persistent plants dont
use the base rate multiplier anymore (as intended)

# This is the 3rd commit message:

Added additional checks for improved performance.

# This is the 4th commit message:

Reworked getRate again and removed getBaseRate

# This is the 5th commit message:

getRate rework