### PR TITLE
Updating labeling on misleading Configuration params

### DIFF
--- a/src/com/untamedears/realisticbiomes/PersistConfig.java
+++ b/src/com/untamedears/realisticbiomes/PersistConfig.java
@@ -12,12 +12,11 @@ public class PersistConfig {
 
 	public boolean enabled;
 	
-	// the period in tick at which data from unloaded chunks will be loaded into
-	// the database
+	// First execution delay. Name of parameter is misleading.
 	public long unloadBatchPeriod;
 	
-	// the maximum time in ms that may be spent unloading data, data no unloaded will be
-	// unloaded at the next opportunity
+	// Delay inbetween executions of unload batches. NOT max time of execution, but rather time inbetween.
+	// Execution time is unbounded.
 	public long unloadBatchMaxTime;
 	
 	// the chance that a grow_event on a block will trigger a plant chunk load


### PR DESCRIPTION
These config parameters are badly misrepresented. 

The call used: https://hub.spigotmc.org/javadocs/spigot/org/bukkit/scheduler/BukkitScheduler.html#runTaskTimer%28org.bukkit.plugin.Plugin,%20java.lang.Runnable,%20long,%20long%29

Batch Period is the delay for first execution. BatchMaxTime is the period -- according to the current implementation.

The run helper used doesn't limit execution time of the task.

Above label changes reflect the true functioning of these components instead of the misleading comments.