### PR TITLE
fix columns growing only straight to 3rd stage

### DIFF
--- a/src/com/untamedears/realisticbiomes/persist/BlockGrower.java
+++ b/src/com/untamedears/realisticbiomes/persist/BlockGrower.java
@@ -30,6 +30,7 @@ import com.untamedears.realisticbiomes.utils.Trees;
 public class BlockGrower {
 
 	public static Logger LOG = Logger.getLogger("RealisticBiomes");
+	private static int COLUMN_PLANT_BLOCK_COUNT = 3;
 	
 	// store the total growth stages of plants
 	public static HashMap<Material, Integer> growthStages = new HashMap<Material, Integer>();
@@ -157,11 +158,7 @@ public class BlockGrower {
 
 	public boolean growColumn(Block block, float growth, DropGrouper dropGrouper) {
 		RealisticBiomes.doLog(Level.FINER, "BlockGrower.growColumn(): " + growth);
-		if (growth < 1.0f) {
-			return false;
-		}
-		
-		
+
 		Material type = block.getType();
 		
 		if (block.getRelative(BlockFace.DOWN).getType() == type) {
@@ -172,7 +169,7 @@ public class BlockGrower {
 			return false;
 		}
 		
-		int stage = (int)(((float)(2))*growth);
+		int stage = (int)(((float)(COLUMN_PLANT_BLOCK_COUNT - 1))*growth);
 		for (int i = 0; i < stage; i++) {
 			block = block.getRelative(BlockFace.UP);
 			


### PR DESCRIPTION
fixes #89 

This PR actually affects cactus growth time in a perhaps unexpected way, with automatic cactus farms which where bugged. I think someone (SkyHG?) complained on the subreddit at some point, I think this is related.

*Previous scenario*: it would take 4hs to produce 1 block. Automatic cactus farms have one space of air and then a solid block above, which makes cactus "pop" when it grows.

*New scenario*: cactus takes 2hs to produce 1 block with an automatic farm.

I think that when balancing, you look at the full growth times of the config, so it most likely was balanced correctly already. Just FYI.